### PR TITLE
Fix hook installation when in a git worktree

### DIFF
--- a/hook/install.go
+++ b/hook/install.go
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	hookPath = ".git/hooks/commit-msg"
+	hookPath = "hooks/commit-msg"
 )
 
 func InstallCommitHook(cfg *config.Config, gitcmd git.GitInterface) {
 	var rootdir string
-	err := gitcmd.Git("rev-parse --show-toplevel", &rootdir)
+	err := gitcmd.Git("rev-parse --git-common-dir", &rootdir)
 	check(err)
 	rootdir = strings.TrimSpace(rootdir)
 	err = os.Chdir(rootdir)


### PR DESCRIPTION
In a git worktree .git is actually a file that points to the location
of the woktree .git directory.  To get the right location for commit
hook installation the --git-common-dir flag needs to be used instead.
